### PR TITLE
Add claude-opus-4-1-20250805 model to Anthropic provider

### DIFF
--- a/proxy/internal/service/model_router.go
+++ b/proxy/internal/service/model_router.go
@@ -99,6 +99,7 @@ func initializeModelProviderMap() map[string]string {
 
 	// Anthropic models
 	anthropicModels := []string{
+		"claude-opus-4-1-20250805",
 		"claude-opus-4-20250514",
 		"claude-sonnet-4-20250514",
 		"claude-3-7-sonnet-20250219",


### PR DESCRIPTION
Added support for the new Claude Opus 4.1 model released in August 2025 to enable routing through the proxy.

🤖 Generated with [Claude Code](https://claude.ai/code)