### PR TITLE
Fall back to OpenAI backend for unknown models

### DIFF
--- a/proxy/internal/service/model_router.go
+++ b/proxy/internal/service/model_router.go
@@ -226,7 +226,8 @@ func (r *ModelRouter) getProviderNameForModel(model string) string {
 			return pattern.provider
 		}
 	}
-	// Default to anthropic (this is an Anthropic proxy after all)
-	r.logger.Printf("ℹ️  Model '%s' has no matching pattern, defaulting to anthropic", model)
-	return "anthropic"
+	// Default to OpenAI, as Anthropic models are covered by the providerPatterns,
+	// and other unknown models are likely served by custom OpenAI compatible
+	// backends.
+	return "openai"
 }


### PR DESCRIPTION
The Anthropic models are all `claude-` prefixed and already caught by the providerPatterns list, so any unknown model is likely to be a custom model provided by an OpenAI compatible endpoint.